### PR TITLE
Make tag-std attributes to work and steps to run `cargo safety-tool`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ goto-transcoder
 # already existing elements were commented out
 
 #/target
+
+# tag-std / rapx's cache
+data.sqlite3

--- a/library/Cargo.lock
+++ b/library/Cargo.lock
@@ -30,6 +30,7 @@ version = "0.0.0"
 dependencies = [
  "compiler_builtins",
  "core",
+ "safety",
 ]
 
 [[package]]
@@ -72,6 +73,10 @@ dependencies = [
 [[package]]
 name = "core"
 version = "0.0.0"
+dependencies = [
+ "safety",
+ "safety-tool-lib",
+]
 
 [[package]]
 name = "coretests"
@@ -214,6 +219,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
 name = "proc_macro"
 version = "0.0.0"
 dependencies = [
@@ -227,6 +265,15 @@ name = "profiler_builtins"
 version = "0.0.0"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+dependencies = [
+ "proc-macro2",
 ]
 
 [[package]]
@@ -315,6 +362,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "safety"
+version = "0.1.0"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "safety-tool-lib"
+version = "0.1.0"
+dependencies = [
+ "safety-tool-macro",
+ "safety-tool-parser",
+]
+
+[[package]]
+name = "safety-tool-macro"
+version = "0.1.0"
+dependencies = [
+ "safety-tool-parser",
+]
+
+[[package]]
+name = "safety-tool-parser"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -343,6 +424,7 @@ dependencies = [
  "rand",
  "rand_xorshift",
  "rustc-demangle",
+ "safety",
  "std_detect",
  "unwind",
  "wasi",
@@ -358,6 +440,27 @@ dependencies = [
  "libc",
  "rustc-std-workspace-alloc",
  "rustc-std-workspace-core",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -379,6 +482,12 @@ dependencies = [
  "libc",
  "std",
 ]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unicode-width"
@@ -412,6 +521,12 @@ dependencies = [
  "gimli",
  "rustc-std-workspace-core",
 ]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"

--- a/library/Cargo.lock
+++ b/library/Cargo.lock
@@ -75,7 +75,7 @@ name = "core"
 version = "0.0.0"
 dependencies = [
  "safety",
- "safety-tool-lib",
+ "safety-tool-macro",
 ]
 
 [[package]]
@@ -372,16 +372,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "safety-tool-lib"
-version = "0.1.0"
-dependencies = [
- "safety-tool-macro",
- "safety-tool-parser",
-]
-
-[[package]]
 name = "safety-tool-macro"
 version = "0.1.0"
+source = "git+https://github.com/Artisan-Lab/tag-std.git?rev=f2f1b9c#f2f1b9cce545140e10d20618697c82e5c179be1a"
 dependencies = [
  "safety-tool-parser",
 ]
@@ -389,6 +382,7 @@ dependencies = [
 [[package]]
 name = "safety-tool-parser"
 version = "0.1.0"
+source = "git+https://github.com/Artisan-Lab/tag-std.git?rev=f2f1b9c#f2f1b9cce545140e10d20618697c82e5c179be1a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/library/core/Cargo.toml
+++ b/library/core/Cargo.toml
@@ -17,6 +17,7 @@ bench = false
 
 [dependencies]
 safety = {path = "../contracts/safety" }
+safety-tool-lib = {path = "../../../tag-std/demo/safety-tool-lib/" }
 
 [features]
 # Make panics and failed asserts immediately abort without formatting any message

--- a/library/core/Cargo.toml
+++ b/library/core/Cargo.toml
@@ -17,7 +17,7 @@ bench = false
 
 [dependencies]
 safety = {path = "../contracts/safety" }
-safety-tool-lib = {path = "../../../tag-std/demo/safety-tool-lib/" }
+safety-tool-macro = { git = "https://github.com/Artisan-Lab/tag-std.git", rev = "f2f1b9c" }
 
 [features]
 # Make panics and failed asserts immediately abort without formatting any message
@@ -33,6 +33,7 @@ debug_typeid = []
 [lints.rust.unexpected_cfgs]
 level = "warn"
 check-cfg = [
+    'cfg(kani)',
     'cfg(bootstrap)',
     'cfg(no_fp_fmt_parse)',
     # core use #[path] imports to portable-simd `core_simd` crate

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -43,6 +43,8 @@
 //!    which do not trigger a panic can be assured that this function is never
 //!    called. The `lang` attribute is called `eh_personality`.
 
+#![feature(register_tool)]
+#![register_tool(rapx)]
 #![stable(feature = "core", since = "1.6.0")]
 #![doc(
     html_playground_url = "https://play.rust-lang.org/",

--- a/library/core/src/mem/maybe_uninit.rs
+++ b/library/core/src/mem/maybe_uninit.rs
@@ -1,3 +1,5 @@
+use safety_tool_macro::*;
+
 use crate::any::type_name;
 use crate::mem::ManuallyDrop;
 use crate::{fmt, intrinsics, ptr, slice};
@@ -611,7 +613,7 @@ impl<T> MaybeUninit<T> {
     #[inline(always)]
     #[rustc_diagnostic_item = "assume_init"]
     #[track_caller]
-    #[safety::precond::Init(self, T, 1)]
+    #[Precond_Init(self, T, 1)]
     pub const unsafe fn assume_init(self) -> T {
         // SAFETY: the caller must guarantee that `self` is initialized.
         // This also means that `self` must be a `value` variant.

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -396,6 +396,8 @@
 // There are many unsafe functions taking pointers that don't dereference them.
 #![allow(clippy::not_unsafe_ptr_arg_deref)]
 
+use safety_tool_macro::*;
+
 use crate::cmp::Ordering;
 use crate::intrinsics::const_eval_select;
 #[cfg(kani)]
@@ -520,14 +522,10 @@ mod mut_ptr;
 #[inline(always)]
 #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
 #[rustc_diagnostic_item = "ptr_copy_nonoverlapping"]
-#[safety::precond::ValidPtr(src, T, count)]
-#[safety::precond::Align(src, T)]
-#[safety::precond::NonVolatile(src, T, count)]
-#[safety::precond::ValidPtr(dst, T, count)]
-#[safety::precond::Align(dst, T)]
-#[safety::precond::NonVolatile(src, T, count)]
-#[safety::precond::NonOverlap(src, dst, T, count)]
-#[safety::option::Trait(T, Copy)]
+// #[Precond_Align(dst, T)]
+#[Precond_NotVolatile(src, T, count)]
+#[Precond_NotOverlap(src, dst, T, count)]
+// #[rapx_::option::Trait(T, Copy)]
 pub const unsafe fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: usize) {
     ub_checks::assert_unsafe_precondition!(
         check_language_ub,
@@ -625,13 +623,13 @@ pub const unsafe fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: us
 #[inline(always)]
 #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
 #[rustc_diagnostic_item = "ptr_copy"]
-#[safety::precond::ValidPtr(src, T, count)]
-#[safety::precond::Align(src, T)]
-#[safety::precond::NonVolatile(src, T, count)]
-#[safety::precond::ValidPtr(dst, T, count)]
-#[safety::precond::Align(dst, T)]
-#[safety::precond::NonVolatile(src, T, count)]
-#[safety::option::Trait(T, Copy)]
+// #[Precond_ValidPtr(src, T, count)]
+#[Precond_Align(src, T)]
+// #[Precond_NonVolatile(src, T, count)]
+// #[Precond_ValidPtr(dst, T, count)]
+#[Precond_Align(dst, T)]
+// #[Precond_NonVolatile(src, T, count)]
+// #[rapx_::option::Trait(T, Copy)]
 pub const unsafe fn copy<T>(src: *const T, dst: *mut T, count: usize) {
     // SAFETY: the safety contract for `copy` must be upheld by the caller.
     unsafe {
@@ -1299,12 +1297,9 @@ pub const fn slice_from_raw_parts_mut<T>(data: *mut T, len: usize) -> *mut [T] {
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_const_stable(feature = "const_swap", since = "1.85.0")]
 #[rustc_diagnostic_item = "ptr_swap"]
-#[safety::precond::ValidPtr(x, T, count)]
-#[safety::precond::Align(x, T)]
-#[safety::precond::NonVolatile(x, T, count)]
-#[safety::precond::ValidPtr(y, T, count)]
-#[safety::precond::Align(y, T)]
-#[safety::precond::NonVolatile(y, T, count)]
+// #[Precond_ValidPtr(y, T, count)]
+#[Precond_Align(y, T)]
+#[Precond_NotVolatile(y, T, count)]
 pub const unsafe fn swap<T>(x: *mut T, y: *mut T) {
     // Give ourselves some scratch space to work with.
     // We do not have to worry about drops: `MaybeUninit` does nothing when dropped.
@@ -1403,13 +1398,13 @@ pub const unsafe fn swap<T>(x: *mut T, y: *mut T) {
 #[rustc_diagnostic_item = "ptr_swap_nonoverlapping"]
 #[rustc_allow_const_fn_unstable(const_eval_select)] // both implementations behave the same
 #[track_caller]
-#[safety::precond::ValidPtr(x, T, count)]
-#[safety::precond::Align(x, T)]
-#[safety::precond::NonVolatile(x, T, count)]
-#[safety::precond::ValidPtr(y, T, count)]
-#[safety::precond::Align(y, T)]
-#[safety::precond::NonVolatile(y, T, count)]
-#[safety::precond::NonOverlap(x, y, T, count)]
+// #[Precond_ValidPtr(x, T, count)]
+// #[Precond_Align(x, T)]
+// #[Precond_NonVolatile(x, T, count)]
+// #[Precond_ValidPtr(y, T, count)]
+#[Precond_Align(y, T)]
+#[Precond_NotVolatile(y, T, count)]
+#[Precond_NotOverlap(x, y, T, count)]
 pub const unsafe fn swap_nonoverlapping<T>(x: *mut T, y: *mut T, count: usize) {
     ub_checks::assert_unsafe_precondition!(
         check_library_ub,
@@ -1936,8 +1931,8 @@ pub const unsafe fn read_unaligned<T>(src: *const T) -> T {
 #[rustc_const_stable(feature = "const_ptr_write", since = "1.83.0")]
 #[rustc_diagnostic_item = "ptr_write"]
 #[track_caller]
-#[safety::precond::ValidPtr(dst, T, 1)]
-#[safety::precond::Align(dst, T)]
+// #[Precond_ValidPtr(dst, T, 1)]
+#[Precond_Align(dst, T)]
 pub const unsafe fn write<T>(dst: *mut T, src: T) {
     // Semantically, it would be fine for this to be implemented as a
     // `copy_nonoverlapping` and appropriate drop suppression of `src`.

--- a/library/core/src/ptr/mut_ptr.rs
+++ b/library/core/src/ptr/mut_ptr.rs
@@ -1,4 +1,5 @@
 use safety::{ensures, requires};
+use safety_tool_macro::*;
 
 use super::*;
 use crate::cmp::Ordering::{Equal, Greater, Less};
@@ -1055,8 +1056,8 @@ impl<T: ?Sized> *mut T {
     // Otherwise, for non-unit types, ensure that `self` and `result` point to the same allocated object,
     // verifying that the result remains within the same allocation as `self`.
     #[ensures(|result| (core::mem::size_of::<T>() == 0) || core::ub_checks::same_allocation(self as *const T, *result as *const T))]
-    #[safety::precond::InBound(self, T, count)]
-    #[safety::precond::ValidNum(size_of(T)*count, <=isize::MAX)]
+    #[Precond_InBound(self, T, count)]
+    #[Precond_ValidNum(size_of(T)*count, size_of(T)*count<=isize::MAX)]
     pub const unsafe fn add(self, count: usize) -> Self
     where
         T: Sized,
@@ -1196,7 +1197,7 @@ impl<T: ?Sized> *mut T {
     // Otherwise, for non-unit types, ensure that `self` and `result` point to the same allocated object,
     // verifying that the result remains within the same allocation as `self`.
     #[ensures(|result| (core::mem::size_of::<T>() == 0) || core::ub_checks::same_allocation(self as *const T, *result as *const T))]
-    #[safety::precond::InBound(self, T, -count)]
+    #[Precond_InBound(self, T, -count)]
     pub const unsafe fn sub(self, count: usize) -> Self
     where
         T: Sized,

--- a/library/core/src/slice/raw.rs
+++ b/library/core/src/slice/raw.rs
@@ -1,5 +1,7 @@
 //! Free functions to create `&[T]` and `&mut [T]`.
 
+use safety_tool_macro::*;
+
 use crate::ops::Range;
 use crate::{array, ptr, ub_checks};
 
@@ -121,13 +123,13 @@ use crate::{array, ptr, ub_checks};
 #[must_use]
 #[rustc_diagnostic_item = "slice_from_raw_parts"]
 #[track_caller]
-#[safety::precond::NonNull(data, T)]
-#[safety::precond::ValidPtr(data, T, len)]
-#[safety::precond::Init(data, T, len)]
-#[safety::precond::Alive(data, a)]
-#[safety::hazard::Alias(data, _)]
-#[safety::precond::Align(data, T)]
-#[safety::precond::ValidNum(size_of(T)*len, <=isize::MAX)]
+// #[Precond_NonNull(data, T)]
+// #[Precond_ValidPtr(data, T, len)]
+#[Precond_Init(data, T, len)]
+#[Precond_Alive(data, a)]
+#[Hazard_Alias(data, _)]
+#[Precond_Align(data, T)]
+#[Precond_ValidNum(size_of(T)*len, size_of(T)*len<=isize::MAX)]
 pub const unsafe fn from_raw_parts<'a, T>(data: *const T, len: usize) -> &'a [T] {
     // SAFETY: the caller must uphold the safety contract for `from_raw_parts`.
     unsafe {
@@ -183,13 +185,13 @@ pub const unsafe fn from_raw_parts<'a, T>(data: *const T, len: usize) -> &'a [T]
 #[must_use]
 #[rustc_diagnostic_item = "slice_from_raw_parts_mut"]
 #[track_caller]
-#[safety::precond::NonNull(data, T)]
-#[safety::precond::ValidPtr(data, T, len)]
-#[safety::precond::Init(data, T, len)]
-#[safety::precond::Alive(data, a)]
-#[safety::hazard::Alias(data, _)]
-#[safety::precond::Align(data, T)]
-#[safety::precond::ValidNum(size_of(T)*len, <=isize::MAX)]
+// #[Precond_NonNull(data, T)]
+// #[Precond_ValidPtr(data, T, len)]
+#[Precond_Init(data, T, len)]
+// #[Precond_Alive(data, a)]
+#[Hazard_Alias(data, _)]
+#[Precond_Align(data, T)]
+#[Precond_ValidNum(size_of(T)*len, size_of(T)*len<=isize::MAX)]
 pub const unsafe fn from_raw_parts_mut<'a, T>(data: *mut T, len: usize) -> &'a mut [T] {
     // SAFETY: the caller must uphold the safety contract for `from_raw_parts_mut`.
     unsafe {

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,62 @@
+# Run rustfmt with this config (it should be picked up automatically).
+style_edition = "2024"
+use_small_heuristics = "Max"
+merge_derives = false
+group_imports = "StdExternalCrate"
+imports_granularity = "Module"
+use_field_init_shorthand = true
+
+# Files to ignore. Each entry uses gitignore syntax, but `!` prefixes aren't allowed.
+ignore = [
+    "/build/",
+    "/*-build/",
+    "/build-*/",
+    "/vendor/",
+
+    # Some tests are not formatted, for various reasons.
+    "/tests/codegen/simd-intrinsic/", # Many types like `u8x64` are better hand-formatted.
+    "/tests/crashes/",                # Many of these tests contain syntax errors.
+    "/tests/debuginfo/",              # These tests are somewhat sensitive to source code layout.
+    "/tests/incremental/",            # These tests are somewhat sensitive to source code layout.
+    "/tests/pretty/",                 # These tests are very sensitive to source code layout.
+    "/tests/run-make/export",         # These tests contain syntax errors.
+    "/tests/run-make/translation/test.rs", # This test contains syntax errors.
+    "/tests/rustdoc/",                # Some have syntax errors, some are whitespace-sensitive.
+    "/tests/rustdoc-gui/",            # Some tests are sensitive to source code layout.
+    "/tests/rustdoc-ui/",             # Some have syntax errors, some are whitespace-sensitive.
+    "/tests/ui/",                     # Some have syntax errors, some are whitespace-sensitive.
+    "/tests/ui-fulldeps/",            # Some are whitespace-sensitive (e.g. `// ~ERROR` comments).
+
+    # Do not format submodules.
+    "library/backtrace",
+    "library/compiler-builtins",
+    "library/portable-simd",
+    "library/stdarch",
+    "src/doc/book",
+    "src/doc/edition-guide",
+    "src/doc/embedded-book",
+    "src/doc/nomicon",
+    "src/doc/reference",
+    "src/doc/rust-by-example",
+    "src/doc/rustc-dev-guide",
+    "src/llvm-project",
+    "src/tools/cargo",
+    "src/tools/clippy",
+    "src/tools/enzyme",
+    "src/tools/miri",
+    "src/tools/rust-analyzer",
+    "src/tools/rustc-perf",
+    "src/tools/rustfmt",
+    "src/gcc",
+
+    # These are ignored by a standard cargo fmt run.
+    "compiler/rustc_codegen_cranelift/scripts",
+    "compiler/rustc_codegen_gcc/tests",
+    # Code automatically generated and included.
+    "compiler/rustc_codegen_gcc/src/intrinsic/archs.rs",
+    "compiler/rustc_codegen_gcc/example",
+
+    # Rustfmt doesn't support use closures yet
+    "tests/mir-opt/ergonomic-clones/closure.rs",
+    "tests/codegen/ergonomic-clones/closure.rs",
+]


### PR DESCRIPTION
```bash
cd verify-rust-std

# must install safety-tool and cargo-safety-tool with current toolchain 06-02
cargo install safety-tool --git https://github.com/Artisan-Lab/tag-std.git --rev f2f1b9c --locked --force

# compile libcore through cargo-safety-tool
cd library/core
cargo safety-tool
```

---

To see if cargo-safety-tool works for custom Memo property, uncomment this line

https://github.com/os-checker/verify-rust-std/blob/9bb1006386efeefbd1a337bdbea49b1621c64f0a/library/core/src/slice/mod.rs#L651-L660

run `cargo safety-tool` as described above, and you'll see

```rust
error: `Property_slice_get_unchecked` is not discharged
    --> core/src/fmt/mod.rs:1438:38
     |
1428 | pub fn write(output: &mut dyn Write, args: Arguments<'_>) -> Result {
1429 |     let mut formatter = Formatter::new(output, FormattingOptions::new());
1430 |     let mut idx = 0;
1431 |
1432 |     match args.fmt {
1433 |         None => {
1434 |             // We can use default formatting parameters for all arguments.
1435 |             for (i, arg) in args.args.iter().enumerate() {
1436 |                 // SAFETY: args.args and args.pieces come from the same Arguments,
1437 |                 // which guarantees the indexes are always within bounds.
1438 |                 let piece = unsafe { args.pieces.get_unchecked(i) };
     |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ For this unsafe call.
1439 |                 if !piece.is_empty() {
1440 |                     formatter.buf.write_str(*piece)?;
1441 |                 }
1442 |
```